### PR TITLE
React-modalのエラー解消

### DIFF
--- a/app/javascript/src/components/StudyModal/StudyModal.jsx
+++ b/app/javascript/src/components/StudyModal/StudyModal.jsx
@@ -22,6 +22,8 @@ class StudyModal extends Component {
   constructor(props) {
     super(props);
 
+    Modal.setAppElement('#root')
+
     this.state = {
       modalIsOpen: true,
       currentSlide: 0,

--- a/app/javascript/src/components/Subjects/Subjects.jsx
+++ b/app/javascript/src/components/Subjects/Subjects.jsx
@@ -12,7 +12,6 @@ import Subject from './Subject'
 class Subjects extends React.Component {
   constructor(props) {
     super(props)
-    console.log('hoge')
 
     this.state = {
       lessons: []


### PR DESCRIPTION
・react-modalのエラー「Warning: react-modal: App element is not defined.」を解消
・Subjects.jsxに「console.log('hoge')」が書かれていたので削除